### PR TITLE
Typo fixed in documentation

### DIFF
--- a/achemso.dtx
+++ b/achemso.dtx
@@ -448,7 +448,7 @@ This work consists of the files achemso.dtx,
 %\begin{itemize}
 %  \item \pkg{caption}
 %  \item \pkg{float}
-%  \item \pkg{geometery}
+%  \item \pkg{geometry}
 %  \item \pkg{natbib}
 %  \item \pkg{setspace}
 %  \item \pkg{xkeyval}


### PR DESCRIPTION
Package name "geometery" in documentation changed to "geometry".