### PR TITLE
Changes for ChemRev

### DIFF
--- a/achemso.dtx
+++ b/achemso.dtx
@@ -3602,11 +3602,18 @@
 %<*chreay>
 \ProvidesFile{achemso-chreay.cfg}
   [2024-01-30 v3.13g achemso configuration: Chem. Rev.]
+  \setkeys{acs}{
+    etalmode      = truncate,
+    maxauthors    = 10
+  }
 \def\acs@type@default{review}
 \def\acs@type@list{review}
 %    \end{macrocode}
 % The references section is numbered in \emph{Chem.\ Rev.}
 %    \begin{macrocode}
+\floatstyle{plaintop}
+\restylefloat{scheme}
+\floatstyle{plain}
 \def\bibsection{\acs@section{\refname}}
 %</chreay>
 %<*cmatex>


### PR DESCRIPTION
I have a current submission with ChemRev that's getting ready for publication, and there were some discrepancies between `achemso` and the editorial guidelines. 

This PR applies these changes for the ChemRev (`chreay`) journal configuration.

In the meantime, one can achieve these changes by using the following in their document preamble, immediately after the `\documentclass` command (adapted from [this closed issue](https://github.com/josephwright/achemso/issues/7#issuecomment-17000752)):

```tex
% Scheme captions go on top
\floatstyle{plaintop}
\restylefloat{scheme}
\floatstyle{plain}
% Set bib options
\setkeys{acs}{etalmode=truncate,maxauthors=10}
```

From the editor's email:

> Journal: Chemical Reviews
> Manuscript ID: cr-2024-\*\*\*\*\*\*.R1
> ...
> In addition to responding to the reviewers’ comments, please complete the following before submitting your revision:
> ...
> Please note that Scheme captions should appear directly above the scheme.
> ...
> Please include full author list in references. If the author list is very long, listing the first 10 authors with "et al." is acceptable.

- Admittedly, the editor's note about `maxauthors` could be taken to mean that the default setting of `15` or the full author list (`maxauthors = 0`) would be acceptable as well, so that could be left out of the PR. I chose to use 10 as specified, and because review articles tend to have a large number of references, so shortening the reference list is, in my opinion, a good thing, but I'll leave it to you whether `maxauthors` should be changed.