### PR TITLE
Update achemso-demo.tex-Fix rendering of Keywords

### DIFF
--- a/achemso-demo.tex
+++ b/achemso-demo.tex
@@ -5,6 +5,7 @@
 %% the target journal and optionally the manuscript type.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \documentclass[journal=jacsat,manuscript=article]{achemso}
+\setkeys{acs}{keywords = true}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Place any additional packages needed here.  Only include packages


### PR DESCRIPTION
In the current .tex file, although the keywords are typeset in the achemso-demo.tex file, they are not rendered in the final PDF. By adding the command \setkeys{acs}{keywords = true}, the keywords are correctly displayed in compliance with the submission guidelines.